### PR TITLE
Debounce instead of throttle window resize events

### DIFF
--- a/List.js
+++ b/List.js
@@ -263,7 +263,7 @@ define([
 
 			// add window resize handler, with reference for later removal if needed
 			this._listeners.push(this._resizeHandle = listen(window, 'resize',
-				miscUtil.throttleDelayed(winResizeHandler, this)));
+				miscUtil.debounce(winResizeHandler, this, 200)));
 		},
 
 		postCreate: function () {


### PR DESCRIPTION
In cases where a large number of grids are used (50+ in our case), resizing can cause browsers to become unresponsive. The current implementation of "throttle" is actually permitting resize calculations once per grid every 15ms. Calculating dimensions on all our grids generally takes longer than 15ms, and resize calls end up stacking. We ultimately end up with an unresponsive browser while it finishes several hundred resize calculations. After changing orientation to landscape and back quickly in iOS, we need to wait upwards of 10 seconds for the browser to finish.

I have tested debounce and confirm that it resolves performance issues in the project I'm working on.
